### PR TITLE
Fixes for printing status line in pcap mode and flushing stdout

### DIFF
--- a/src/ntt_inspector.c
+++ b/src/ntt_inspector.c
@@ -345,6 +345,7 @@ static void process_avio_input(struct tool_ctx_s *ctx)
 			char *json_stats = tissot_stats_recent_json(ctx->tissot_ctx);
 			if (json_stats != NULL) {
 				printf("%s\n", json_stats);
+				fflush(stdout);
 				free(json_stats);
 			}
 			ctx->last_report_time = cur_time;
@@ -379,6 +380,7 @@ static void tissot_log_cb(void *p, int level, const char *fmt, ...)
 static void tissot_cb(void *user_ctx, const char *json_buf)
 {
 	printf("%s\n", json_buf);
+	fflush(stdout);
 }
 
 int ntt_inspector(int argc, char *argv[])

--- a/src/ntt_inspector.c
+++ b/src/ntt_inspector.c
@@ -318,6 +318,17 @@ static void process_pcap_input(struct tool_ctx_s *ctx)
 
 	int ok = 1;
 	while (ok) {
+		time_t cur_time = time(NULL);
+		if (cur_time > ctx->last_report_time) {
+			char *json_stats = tissot_stats_recent_json(ctx->tissot_ctx);
+			if (json_stats != NULL) {
+				printf("%s\n", json_stats);
+				fflush(stdout);
+				free(json_stats);
+			}
+			ctx->last_report_time = cur_time;
+		}
+
 		usleep(50 * 1000);
 	}
 


### PR DESCRIPTION
These were patches in my working directory that didn't make it into the prior pull request, but they are needed for cases where the stream doesn't have Tissot data